### PR TITLE
Add `formattingToggle.statusBarLabel` settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ By default, Formatting Toggle toggles all formatting settings: `editor.formatOnP
 
 💡 Formatting Toggle was created with formatting settings in mind but allows you to toggle any boolean setting that lives at the root of the VSCode configuration. `editor.codeActionsOnSave` is currently the only deeply nested setting supported.
 
+The Status Bar label can be customized via `formattingToggle.statusBarLabel`, which is also in your editor settings (Code › Preferences › Settings).
+
+Values for `enabled` and `disabled` are distinct, and can include different codicons for each state. See [Product Icon Reference](https://code.visualstudio.com/api/references/icons-in-labels#icon-listing) for more options.
+
 ### Examples
 
 #### Keeping `editor.formatOnPaste` and `editor.formatOnType` enabled at all times:
@@ -67,5 +71,16 @@ By default, Formatting Toggle toggles all formatting settings: `editor.formatOnP
     "editor.formatOnSave",
     "editor.formatOnType"
   ]
+}
+```
+
+#### Customizing the Status Bar label:
+
+```json
+{
+  "formattingToggle.statusBarLabel": {
+    "formattingEnabled": "On $(heart-filled)",
+    "formattingDisabled": "Off $(heart)"
+  },
 }
 ```

--- a/package.json
+++ b/package.json
@@ -44,6 +44,15 @@
       "type": "object",
       "title": "Formatting Toggle’s configuration",
       "properties": {
+        "formattingToggle.statusBarLabel": {
+          "type": "object",
+          "scope": "window",
+          "default": {
+            "formattingEnabled": "Formatting: $(check)",
+            "formattingDisabled": "Formatting: $(x)"
+          },
+          "description": "The Status Bar text and icons displayed when formatting is enabled or disabled."
+        },
         "formattingToggle.affects": {
           "scope": "resource",
           "type": "array",

--- a/src/createStatusBarItem.ts
+++ b/src/createStatusBarItem.ts
@@ -1,4 +1,4 @@
-import { window, StatusBarAlignment } from 'vscode'
+import { window, StatusBarAlignment, StatusBarItem } from 'vscode'
 import { COMMAND_NAME } from './constants'
 import getStatusBarText from './helpers/getStatusBarText'
 
@@ -6,8 +6,8 @@ import getStatusBarText from './helpers/getStatusBarText'
 const PRETTIER_STATUS_BAR_PRIORITY = -1
 const TOOLTIP_TEXT = 'Enable/Disable formatting'
 
-const createStatusBarItem = () => {
-  const statusBarItem = window.createStatusBarItem(
+const createStatusBarItem = (): StatusBarItem => {
+  const statusBarItem: StatusBarItem = window.createStatusBarItem(
     StatusBarAlignment.Right,
     // We substract one so that it is always to the right of the Prettier status
     // bar item. If we didn’t do this, the position could switch randomly.

--- a/src/helpers/getStatusBarText/index.ts
+++ b/src/helpers/getStatusBarText/index.ts
@@ -1,10 +1,23 @@
+import { workspace, WorkspaceConfiguration } from 'vscode'
 import getFormattingStatus from '../getFormattingStatus'
 
-export const ENABLED_TEXT = 'Formatting: $(check)'
-export const DISABLED_TEXT = 'Formatting: $(x)'
+type StatusBarLabelT = {
+  formattingEnabled: string
+  formattingDisabled: string
+};
 
-const getStatusBarText = () => {
+export const getStatusBarText = (): string => {
   const isFormattingActivated = getFormattingStatus()
+
+  const configuration: WorkspaceConfiguration = workspace.getConfiguration();
+  let statusBarLabel: StatusBarLabelT | undefined
+
+  statusBarLabel = configuration.get<StatusBarLabelT>(
+    'formattingToggle.statusBarLabel'
+  );
+
+  const ENABLED_TEXT = statusBarLabel!.formattingEnabled
+  const DISABLED_TEXT = statusBarLabel!.formattingDisabled
 
   return isFormattingActivated ? ENABLED_TEXT : DISABLED_TEXT
 }


### PR DESCRIPTION
# What?

This is a first draft to address #67.

# How?

Adds `formattingToggle.text` to support custom Status Bar label text.

This can be enhanced in multiple ways:

- add support for variations of text on enabled/disabled status
- add support for customization of of enabled/disabled icon

I'd be happy to write tests and build the above out further with separate PRs. Please @ me if interested and I'll wrap up this PR with tests, changes to naming convention, separating `statusBarText` logic out into its own helper, etc.

Thank you for your work on this excellent extension, @Tom-Bonnike!