### PR TITLE
feat: add trimTrailingWhitespace to default options

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export const DEFAULT_AFFECTS_CONFIGURATION = [
   'editor.formatOnPaste',
   'editor.formatOnSave',
   'editor.formatOnType',
+  "files.trimTrailingWhitespace",
 ]
 
 // This should be kept in sync with the default specified in the `package.json`


### PR DESCRIPTION
without this, whitespace will still be removed on save for many users. This option is frusterating to find as well.
